### PR TITLE
Fix FullStockTicketSample client address

### DIFF
--- a/FullStockTickerSample/grpc/FullStockTicker/src/TraderSys.FullStockTickerClientApp/App.xaml.cs
+++ b/FullStockTickerSample/grpc/FullStockTicker/src/TraderSys.FullStockTickerClientApp/App.xaml.cs
@@ -21,7 +21,7 @@ namespace TraderSys.FullStockTickerClientApp
 
             services.AddGrpcClient<FullStockTickerServer.Protos.FullStockTicker.FullStockTickerClient>("grpc", options =>
             {
-                options.Address = new Uri("https://localhost:61282");
+                options.Address = new Uri("http://localhost:5000");
             });
             services.AddSingleton<MainWindow>();
             services.AddSingleton<MainWindowViewModel>();


### PR DESCRIPTION
When I tried to run this out of the box from the command line, it wasn't working. The server was listening on `http://localhost:5000` but the client was trying to connect to `https://localhost:61282`, presumably from an old `launchSettings.json` profile.

On the subject of launch settings, if I open the solution in VS 2022, it generates a `launchSettings.json` file with a random port number. This means it's not going to run from the command line without tweaking the client connection address. I noticed that [these files are ignored](https://github.com/dotnet-architecture/grpc-for-wcf-developers/blob/main/.gitignore#:~:text=**/Properties/launchSettings.json), but should they be? [This StackOverflow question suggests not](https://stackoverflow.com/questions/47377058/should-i-ignore-the-launchsettings-json-file-from-being-committed-in-git). 

I'm thinking they should be added, and the client connection addresses updated accordingly, so anyone running from the command line or from Visual Studio will get the same experience. I'm happy to add to this PR if you think that's the way to go.